### PR TITLE
Fix runtime error on /chat page by handling async store initialization

### DIFF
--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -4,12 +4,17 @@ import { useChatStore } from '@repo/common/store';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { nanoid } from 'nanoid';
+import { FullPageLoader } from '@repo/common/components';
 
 const ChatPage = () => {
     const router = useRouter();
-    const { currentThreadId, createThread } = useChatStore();
+    const { currentThreadId, createThread, isInitialized } = useChatStore();
 
     useEffect(() => {
+        if (!isInitialized) {
+            return; // Wait for the store to be initialized
+        }
+
         if (currentThreadId) {
             router.push(`/chat/${currentThreadId}`);
         } else {
@@ -18,9 +23,13 @@ const ChatPage = () => {
                 router.push(`/chat/${newThreadId}`);
             });
         }
-    }, [currentThreadId, createThread, router]);
+    }, [isInitialized, currentThreadId, createThread, router]);
 
-    return null; // This page will just handle the redirect, so it doesn't need to render anything.
+    if (!isInitialized) {
+        return <FullPageLoader />; // Show a loader while the store is initializing
+    }
+
+    return null; // Render nothing while redirecting
 };
 
 export default ChatPage;

--- a/packages/common/store/chat.store.ts
+++ b/packages/common/store/chat.store.ts
@@ -86,6 +86,7 @@ type State = {
         isAuthenticated: boolean;
         isFetched: boolean;
     };
+    isInitialized: boolean;
 };
 
 type Actions = {
@@ -462,6 +463,7 @@ export const useChatStore = create(
             isFetched: false,
         },
         showSuggestions: true,
+        isInitialized: false,
 
         setCustomInstructions: (customInstructions: string) => {
             const existingConfig = JSON.parse(localStorage.getItem(CONFIG_KEY) || '{}');
@@ -944,6 +946,7 @@ if (typeof window !== 'undefined') {
                 useWebSearch,
                 showSuggestions,
                 customInstructions,
+                isInitialized: true,
             });
 
             // Initialize the shared worker for tab synchronization


### PR DESCRIPTION
The /chat page was causing a client-side runtime error because it was trying to access the chat store before it was fully initialized with data from IndexedDB. This created a race condition.

This commit introduces an `isInitialized` flag to the chat store. The flag is set to true only after the store has been hydrated with data.

The /chat page now waits for this flag to be true before executing its redirect logic. A loading indicator is displayed while the store is being initialized.

This prevents the race condition and resolves the runtime error.